### PR TITLE
Added example using Solana v0 transactions. Currently not working because the Metakeep wallet rejects v0 transactions

### DIFF
--- a/packages/civic-auth-web3/solana/next14-wallet-adapter/yarn.lock
+++ b/packages/civic-auth-web3/solana/next14-wallet-adapter/yarn.lock
@@ -94,12 +94,12 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@civic/auth-web3@0.5.6-beta.4":
-  version "0.5.6-beta.4"
-  resolved "https://registry.yarnpkg.com/@civic/auth-web3/-/auth-web3-0.5.6-beta.4.tgz#86145470d3678ff5363fa63dcd5bfa2b9b248a03"
-  integrity sha512-NGvuH2mTgqqL0x5yOAnrV8e+UgZMEUTBg4cUuNAX/Jnw8FdxXgWp6gAwsyl56QvQUyRpqOVX22cjnQ7OWbpyWA==
+"@civic/auth-web3@*":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@civic/auth-web3/-/auth-web3-0.5.9.tgz#0c3975caeb606b904b572d4a0776031940693a8b"
+  integrity sha512-wchnVbbCtU+r4d5eQ4ZQC69KroitHAA27g5JCJmmRoXqfsLcZuDNqqG44UOWm5Sxe/yGNOFsVjqHx8dynJ9fOg==
   dependencies:
-    "@civic/auth" "0.5.2-beta.1"
+    "@civic/auth" "0.5.5"
     "@noble/hashes" "^1.5.0"
     "@solana/wallet-adapter-base" "^0.9.23"
     "@solana/wallet-standard-features" "^1.3.0"
@@ -114,10 +114,10 @@
     tslib "^2.7.0"
     viem "^2.21.44"
 
-"@civic/auth@0.5.2-beta.1":
-  version "0.5.2-beta.1"
-  resolved "https://registry.yarnpkg.com/@civic/auth/-/auth-0.5.2-beta.1.tgz#1ee4e7765ecb288ecce1b0f0089393bde9ea2a29"
-  integrity sha512-9KBeFNlLKzRKEjyJWEfrXMoR48BKqVzDsD0X01r87lHXNrJ0yWiHhZ1X5uhJ7hbslHmMdoq8pHghCa1owGdLcw==
+"@civic/auth@0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@civic/auth/-/auth-0.5.5.tgz#d6d11943235b774f1aef763c2c3e29ccef8ce158"
+  integrity sha512-UgWVOiWQBmfq7mvju44FOVfBUpoTjsICqdnQtM/4cBGXBGakYtQ9lGMG5u5etohVO4JaH+B+GXFD5gAPXI9l5g==
   dependencies:
     "@civic/iframe-resizer" "0.1.2"
     "@emotion/react" "^11.14.0"


### PR DESCRIPTION
Added example using Solana v0 transactions. Currently not working because the Metakeep wallet rejects v0 transactions.
To test, run the solana/next14-wallet-adapter example with `NEXT_PUBLIC_USE_V0_TX="true"` and try to send some SOL using the form.