### PR TITLE
disable upload of playwright report

### DIFF
--- a/.github/workflows/test-example-app-playwright.yml
+++ b/.github/workflows/test-example-app-playwright.yml
@@ -116,11 +116,12 @@ jobs:
         working-directory: packages/e2e
         run: yarn playwright test ${{ inputs.playwright-spec }} --project=${{ inputs.browser }}
 
-      - name: Upload Playwright Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report-${{ github.job }}-${{ github.run_id }}
-          path: packages/e2e/playwright-report/
-          retention-days: 30
-          overwrite: true 
+      # This is causing tests to fail with dublicate artifact names even though the job is unique
+      # - name: Upload Playwright Report
+      #   if: always()
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: playwright-report-${{ github.job }}-${{ github.run_id }}
+      #     path: packages/e2e/playwright-report/
+      #     retention-days: 30
+      #     overwrite: true 


### PR DESCRIPTION
disable upload of playwright report, as it's failing sometimes with duplicate artifact names even though the job is unique