### PR TITLE
do not auto push version changes from github

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -84,12 +84,3 @@ jobs:
           echo "$AUTH_PROD_VERSION" >> .civic-versions
           echo "$WEB3_BETA_VERSION" >> .civic-versions
           echo "$WEB3_PROD_VERSION" >> .civic-versions
-
-      - name: Commit and push changes
-        if: steps.check-version.outputs.version_changed == 'true'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add .civic-versions
-          git commit -m "Update .civic-versions file for daily test [skip ci]" || echo "No changes to commit"
-          git push 


### PR DESCRIPTION
- we cannot auto-push version changes to files without first creating PRs, and this code was causing the check-version job to fail with new versions