### PR TITLE
use same logic from check versions job in yarn install job to actually get latest version

### DIFF
--- a/.github/workflows/test-example-app-playwright.yml
+++ b/.github/workflows/test-example-app-playwright.yml
@@ -101,38 +101,51 @@ jobs:
 
       - name: Yarn install with latest Civic packages
         run: |
-          # Function to get the absolute latest version (including pre-releases)
+          # Function to get latest version (beta or prod) - adapted from check-versions workflow
           get_latest_version() {
-            local pkg=$1
-            echo "Checking versions for $pkg..." >&2
+            local package=$1
+            local beta_version=$(npm view ${package}@beta version 2>/dev/null || echo "")
+            local prod_version=$(npm view ${package} version 2>/dev/null || echo "")
             
-            # Get the absolute latest version (including pre-releases)
-            local latest_version=$(npm view $pkg versions --json 2>/dev/null | \
-              grep -o '"[^"]*"' | \
-              sed 's/"//g' | \
-              sort -V | \
-              tail -n 1)
+            echo "Package: $package" >&2
+            echo "Beta version: $beta_version" >&2
+            echo "Prod version: $prod_version" >&2
             
-            if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
-              echo "Could not determine latest version for $pkg, using latest tag" >&2
-              echo "${pkg}@latest"
+            if [ -z "$beta_version" ] && [ -z "$prod_version" ]; then
+              echo "Could not determine versions for $package, using latest tag" >&2
+              echo "latest"
+              return
+            fi
+            
+            if [ -z "$beta_version" ]; then
+              echo "Using prod version: $prod_version" >&2
+              echo "$prod_version"
+              return
+            fi
+            
+            if [ -z "$prod_version" ]; then
+              echo "Using beta version: $beta_version" >&2
+              echo "$beta_version"
+              return
+            fi
+            
+            local beta_base=$(echo $beta_version | sed 's/-beta.*//')
+            local prod_base=$prod_version
+            
+            if [[ $(echo -e "$beta_base\n$prod_base" | sort -V | tail -n 1) == "$beta_base" && "$beta_base" != "$prod_base" ]]; then
+              echo "Using beta version: $beta_version" >&2
+              echo "$beta_version"
             else
-              echo "Latest version found: $latest_version" >&2
-              echo "${pkg}@${latest_version}"
+              echo "Using prod version: $prod_version" >&2
+              echo "$prod_version"
             fi
           }
           
           # Check which Civic packages are dependencies and install latest versions
           if grep -q '"@civic/auth"' package.json; then
-            auth_pkg=$(get_latest_version "@civic/auth")
-            echo "Installing $auth_pkg"
-            yarn add "$auth_pkg"
-          fi
-          
-          if grep -q '"@civic/auth-web3"' package.json; then
-            web3_pkg=$(get_latest_version "@civic/auth-web3")
-            echo "Installing $web3_pkg"
-            yarn add "$web3_pkg"
+            auth_version=$(get_latest_version "@civic/auth")
+            echo "Installing @civic/auth@$auth_version"
+            yarn add "@civic/auth@$auth_version"
           fi
           
           # Install remaining dependencies


### PR DESCRIPTION
- use the same logic from check-versions job, which works well, to get and install the latest version
- Can confirm this is working as intended (finally)

```Run # Function to get latest version (beta or prod) - adapted from check-versions workflow
Package: @civic/auth
Beta version: 0.11.0-beta.2
Prod version: 0.11.0
Using prod version: 0.11.0
Installing @civic/auth@0.11.0
yarn add v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency.
info Direct dependencies
└─ @civic/auth@0.11.0
info All dependencies
└─ @civic/auth@0.11.0
Done in 22.27s.
yarn install v1.22.22
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.23s.```