### PR TITLE
Bugfix/implement wait before publish job completes

### DIFF
--- a/.github/workflows/publish-combined-allure-reports.yml
+++ b/.github/workflows/publish-combined-allure-reports.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-    # this job will wait for all the workflows to complete. Unfortunately github does not have a way to wait for all workflows to complete, so using a script instead.
+    # this job will wait for all the workflows to complete. Unfortunately github does not have a way to wait for all workflows to complete. The drawback is that it does the check after each workflow completes.
     # see https://github.com/orgs/community/discussions/16059 for more information
   wait-for-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-combined-allure-reports.yml
+++ b/.github/workflows/publish-combined-allure-reports.yml
@@ -9,34 +9,11 @@ jobs:
     # see https://github.com/orgs/community/discussions/16059 for more information
   wait-for-workflows:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: lewagon/wait-on-check-action@v1.3.4
+      - uses: int128/wait-for-workflows-action@v1.47.0
         with:
-          ref: ${{ github.ref }}
-          check-name: 'Civic Auth Example Apps - E2E Tests (Dev Mode)'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-            
-      - uses: lewagon/wait-on-check-action@v1.3.4
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Civic Auth Example Apps - E2E Tests (Start Mode)'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-            
-      - uses: lewagon/wait-on-check-action@v1.3.4
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Civic Auth Web3 Example Apps - E2E Tests (Dev Mode)'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-            
-      - uses: lewagon/wait-on-check-action@v1.3.4
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Civic Auth Web3 Example Apps - E2E Tests (Start Mode)'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
+          fail-fast: false
 
   publish-combined-reports:
     name: "Publish Combined Allure Reports"

--- a/.github/workflows/publish-combined-allure-reports.yml
+++ b/.github/workflows/publish-combined-allure-reports.yml
@@ -2,23 +2,13 @@ name: Publish Combined Allure Reports
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
-    # this job will wait for all the workflows to complete. Unfortunately github does not have a way to wait for all workflows to complete. The drawback is that it does the check after each workflow completes.
-    # see https://github.com/orgs/community/discussions/16059 for more information
-  wait-for-workflows:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: int128/wait-for-workflows-action@v1.47.0
-        with:
-          fail-fast: false
-
   publish-combined-reports:
     name: "Publish Combined Allure Reports"
     runs-on: ubuntu-latest
-    needs: wait-for-workflows
     if: always()
     permissions:
       contents: write
@@ -26,6 +16,20 @@ jobs:
       id-token: write
       pages: write
     steps:
+      # Implementing 15 minute wait in order for the jobs to complete.  
+      # Unfortunately this is the cleanest solution I could find, and is much more readable in the github runs.
+      # See https://github.com/orgs/community/discussions/16059 for more information.
+      - name: Wait for test workflows to complete
+        run: |
+          echo "⏳ Waiting for test workflows to complete..."
+          echo "This workflow will wait up to 15 minutes for test workflows to finish"
+          
+          # Simple approach: just wait a reasonable amount of time
+          # The download steps will handle missing artifacts gracefully
+          sleep 900  # Wait 15 minutes for workflows to start and make progress
+          
+          echo "✅ Wait period completed, proceeding with artifact download"
+
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish-combined-allure-reports.yml
+++ b/.github/workflows/publish-combined-allure-reports.yml
@@ -1,60 +1,47 @@
 name: Publish Combined Allure Reports
 
 on:
-  workflow_run:
-    workflows: [
-      "Civic Auth Example Apps - E2E Tests (Dev Mode)",
-      "Civic Auth Example Apps - E2E Tests (Start Mode)", 
-      "Civic Auth Web3 Example Apps - E2E Tests (Dev Mode)",
-      "Civic Auth Web3 Example Apps - E2E Tests (Start Mode)"
-    ]
-    types: [completed]
+  push:
   workflow_dispatch:
 
 jobs:
-  wait-for-all:
+    # this job will wait for all the workflows to complete. Unfortunately github does not have a way to wait for all workflows to complete, so using a script instead.
+    # see https://github.com/orgs/community/discussions/16059 for more information
+  wait-for-workflows:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for all workflows
-        uses: actions/github-script@v7
+      - uses: lewagon/wait-on-check-action@v1.3.4
         with:
-          script: |
-            const workflows = [
-              "Civic Auth Example Apps - E2E Tests (Dev Mode)",
-              "Civic Auth Example Apps - E2E Tests (Start Mode)", 
-              "Civic Auth Web3 Example Apps - E2E Tests (Dev Mode)",
-              "Civic Auth Web3 Example Apps - E2E Tests (Start Mode)"
-            ];
+          ref: ${{ github.ref }}
+          check-name: 'Civic Auth Example Apps - E2E Tests (Dev Mode)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
             
-            // Check if all workflows have completed
-            const runs = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'main',
-              per_page: 100
-            });
+      - uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Civic Auth Example Apps - E2E Tests (Start Mode)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
             
-            const latestRuns = new Map();
-            runs.data.workflow_runs.forEach(run => {
-              const key = run.name;
-              if (!latestRuns.has(key) || run.created_at > latestRuns.get(key).created_at) {
-                latestRuns.set(key, run);
-              }
-            });
+      - uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Civic Auth Web3 Example Apps - E2E Tests (Dev Mode)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
             
-            const allCompleted = workflows.every(workflow => {
-              const run = latestRuns.get(workflow);
-              return run && run.status === 'completed';
-            });
-            
-            if (!allCompleted) {
-              core.setFailed('Not all workflows have completed yet');
-            }
+      - uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Civic Auth Web3 Example Apps - E2E Tests (Start Mode)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
 
   publish-combined-reports:
     name: "Publish Combined Allure Reports"
     runs-on: ubuntu-latest
-    needs: wait-for-all
+    needs: wait-for-workflows
     if: always()
     permissions:
       contents: write


### PR DESCRIPTION
- current solution publishes after EACH workflow completes.  Github does not have a workaround, so instead I'm implementing a 15 min wait until publish job executes.  See https://github.com/orgs/community/discussions/16059 for more information.
- This will prevent GH actions from looking so incredibly cluttered, i.e. the screenshot below
<img width="865" height="752" alt="Screenshot 2025-09-24 at 6 46 39 AM" src="https://github.com/user-attachments/assets/b3e0cdaf-14e1-4d8f-af58-a4079d3afda6" />
